### PR TITLE
Issue7 mbc image processor

### DIFF
--- a/mbc-image-processor/.editorconfig
+++ b/mbc-image-processor/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps configure editor settings consistently
+# between developers working on a project.
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/mbc-image-processor/.gitignore
+++ b/mbc-image-processor/.gitignore
@@ -1,0 +1,15 @@
+# Ignore configuration files that may contain sensitive information.
+/messagebroker-config
+
+# Ignor composer working files
+composer.lock
+/vendor/
+
+# Ignor testing working files
+tests/phpunit.xml
+
+# Ignor config settings with sensative account creds
+config.inc
+
+# Ignor OSX system files
+.DS_Store

--- a/mbc-image-processor/composer.json
+++ b/mbc-image-processor/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">= 5.3.0",
     "DoSomething/messagebroker-phplib": "0.2.*",
-    "dosomething/mb-toolbox": "0.5.*",
+    "dosomething/mb-toolbox": "0.6.*",
     "dosomething/stathat": "1.*"
   },
   "require-dev": {

--- a/mbc-image-processor/composer.json
+++ b/mbc-image-processor/composer.json
@@ -23,7 +23,7 @@
   },
   "autoload": {
     "psr-4": {
-      "DoSomething\\MBC_Image_Processor\\": "src/"
+      "DoSomething\\MBC_ImageProcessor\\": "src/"
     }
   },
   "scripts": {

--- a/mbc-image-processor/mbc-image-processor.php
+++ b/mbc-image-processor/mbc-image-processor.php
@@ -11,12 +11,23 @@ define('CONFIG_PATH',  __DIR__ . '/messagebroker-config');
 
 // Load up the Composer autoload magic
 require_once __DIR__ . '/vendor/autoload.php';
-use DoSomething\MBC_ImageProcessor\MBC_ImageProcessor;
+use DoSomething\MBC_ImageProcessor\MBC_ImageProcessingConsumer;
+
+use DoSomething\StatHat\Client as StatHat;
+use DoSomething\MB_Toolbox\MB_Toolbox;
 
 // Load configuration settings specific to this application
 require_once __DIR__ . '/mbc-image-processor.config.inc';
 
-
-// Kick off - blocking, waiting for messages in the queue
+// Create objects for injection into MBC_ImageProcessor
 $mb = new MessageBroker($credentials, $config);
-$mb->consumeMessage(array(new MBC_ImageProcessor($mb, $settings), 'consumeImageProcessingQueue'));
+$sh = new StatHat([
+  'ez_key' => $settings['stathat_ez_key'],
+  'debug' => $settings['stathat_disable_tracking']
+]);
+$tb = new MB_Toolbox($settings);
+
+// Kick off - block, waiting for messages in queue
+echo '------- mbc-logging-gateway START - ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;
+$mb->consumeMessage(array(new  MBC_ImageProcessingConsumer($mb, $sh, $tb, $settings), 'consumeImageProcessingQueue'));
+echo '------- mbc-logging-gateway END - ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;

--- a/mbc-image-processor/mbc-image-processor.php
+++ b/mbc-image-processor/mbc-image-processor.php
@@ -27,7 +27,8 @@ $sh = new StatHat([
 ]);
 $tb = new MB_Toolbox($settings);
 
+
 // Kick off - block, waiting for messages in queue
 echo '------- mbc-logging-gateway START - ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;
-$mb->consumeMessage(array(new  MBC_ImageProcessingConsumer($mb, $sh, $tb, $settings), 'consumeImageProcessingQueue'));
+$mb->consumeMessage(array(new MBC_ImageProcessingConsumer($mb, $sh, $tb, $settings), 'consumeImageProcessingQueue'));
 echo '------- mbc-logging-gateway END - ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;

--- a/mbc-image-processor/src/MBC_BaseConsumer.php
+++ b/mbc-image-processor/src/MBC_BaseConsumer.php
@@ -83,4 +83,14 @@ abstract class MBC_BaseConsumer
     $this->message = unserialize($payload->body);
   }
 
+  /**
+   * Sets values for processing based on contents of message from consumed queue.
+   */
+  abstract protected function setter();
+
+  /**
+   * Process message from consumed queue.
+   */
+  abstract protected function process();
+
 }

--- a/mbc-image-processor/src/MBC_BaseConsumer.php
+++ b/mbc-image-processor/src/MBC_BaseConsumer.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace DoSomething;
+
+use DoSomething\StatHat\Client as StatHat;
+use DoSomething\MB_Toolbox\MB_Toolbox;
+
+/*
+ * MBC_UserAPICampaignActivity.class.in: Used to process the transactionalQueue
+ * entries that match the campaign.*.* binding.
+ */
+abstract class MBC_BaseConsumer
+{
+
+  /**
+   * Message Broker connection to RabbitMQ
+   *
+   * @var object
+   */
+  protected $messageBroker;
+  
+  /**
+   * StatHat object for logging of activity
+   *
+   * @var object
+   */
+  protected $statHat;
+  
+  /**
+   * Message Broker Toolbox - collection of utility methods used by many of the
+   * Message Broker producer and consumer applications.
+   *
+   * @var object
+   */
+  protected $toolbox;
+
+  /**
+   * Setting from external services - Mail chimp.
+   *
+   * @var array
+   */
+  protected $settings;
+  
+  /**
+   * Value of message from queue to be consumed / processed.
+   *
+   * @var array
+   */
+  protected $messge;
+
+  /**
+   * Constructor for MBC_BaseConsumer - all consumer applications should extend this base class.
+   *
+   * @param object $messageBroker
+   *   The Message Broker object used to interface the RabbitMQ server exchanges and related queues.
+   *  
+   * @param object $statHat
+   *   Track application activity by triggering counters in StatHat service.
+   *
+   * @param object $toolbox
+   *   A collection of common tools for the Message Broker system.
+   *   
+   * @param array $settings
+   *   Settings from internal and external services used by the application.
+   */
+  protected function __construct($messageBroker, StatHat $statHat, MB_Toolbox $toolbox, $settings) {
+    
+     echo 'MBC_BaseConsumer __construct()', PHP_EOL;
+
+    $this->messageBroker = $messageBroker;
+    $this->statHat = $statHat;
+    $this->toolbox = $toolbox;
+    $this->settings = $settings;
+  }
+
+  /**
+   * Initial method triggered by blocked call in base mbc-??-??.php file. The $payload is the
+   * contents of the message being processed from the queue.
+   *
+   * @param array $payload
+   *   The contents of the queue entry
+   */
+  protected function consumeQueue($payload) {
+    $this->message = unserialize($payload->body);
+  }
+
+}

--- a/mbc-image-processor/src/MBC_BaseConsumer.php
+++ b/mbc-image-processor/src/MBC_BaseConsumer.php
@@ -64,8 +64,6 @@ abstract class MBC_BaseConsumer
    *   Settings from internal and external services used by the application.
    */
   protected function __construct($messageBroker, StatHat $statHat, MB_Toolbox $toolbox, $settings) {
-    
-     echo 'MBC_BaseConsumer __construct()', PHP_EOL;
 
     $this->messageBroker = $messageBroker;
     $this->statHat = $statHat;

--- a/mbc-image-processor/src/MBC_BaseConsumer.php
+++ b/mbc-image-processor/src/MBC_BaseConsumer.php
@@ -46,7 +46,7 @@ abstract class MBC_BaseConsumer
    *
    * @var array
    */
-  protected $messge;
+  protected $message;
 
   /**
    * Constructor for MBC_BaseConsumer - all consumer applications should extend this base class.
@@ -78,15 +78,18 @@ abstract class MBC_BaseConsumer
    * @param array $payload
    *   The contents of the queue entry
    */
-  protected function consumeQueue($payload) {
+  public function consumeQueue($payload) {
 
     $this->message = unserialize($payload->body);
   }
 
   /**
    * Sets values for processing based on contents of message from consumed queue.
+   *
+   * @param array $message
+   *  The payload of the unseralized message being processed.
    */
-  abstract protected function setter();
+  abstract protected function setter($message);
 
   /**
    * Process message from consumed queue.

--- a/mbc-image-processor/src/MBC_BaseConsumer.php
+++ b/mbc-image-processor/src/MBC_BaseConsumer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoSomething;
+namespace DoSomething\MBC_ImageProcessor;
 
 use DoSomething\StatHat\Client as StatHat;
 use DoSomething\MB_Toolbox\MB_Toolbox;
@@ -63,7 +63,7 @@ abstract class MBC_BaseConsumer
    * @param array $settings
    *   Settings from internal and external services used by the application.
    */
-  protected function __construct($messageBroker, StatHat $statHat, MB_Toolbox $toolbox, $settings) {
+  public function __construct($messageBroker, StatHat $statHat, MB_Toolbox $toolbox, $settings) {
 
     $this->messageBroker = $messageBroker;
     $this->statHat = $statHat;
@@ -79,6 +79,7 @@ abstract class MBC_BaseConsumer
    *   The contents of the queue entry
    */
   protected function consumeQueue($payload) {
+
     $this->message = unserialize($payload->body);
   }
 

--- a/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
+++ b/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
@@ -15,7 +15,7 @@ class MBC_ImageProcessingConsumer extends MBC_BaseConsumer
   /**
    * Message Broker connection to RabbitMQ
    */
-  private $imagePath;
+  protected $imagePath;
 
   /**
    * Initial method triggered by blocked call in mbc-image-processor.php. The $payload is the

--- a/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
+++ b/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
@@ -1,0 +1,51 @@
+<?php
+namespace DoSomething\MBC_ImageProcessor;
+
+use DoSomething\StatHat\Client as StatHat;
+use DoSomething\MB_Toolbox\MB_Toolbox;
+use DoSomething\MMBC_ImageProcessor\MBC_ImageProcessor;
+
+/*
+ * MBC_UserAPICampaignActivity.class.in: Used to process the transactionalQueue
+ * entries that match the campaign.*.* binding.
+ */
+class MBC_ImageProcessingConsumer extends MBC_BaseConsumer
+{
+
+  /**
+   * Message Broker connection to RabbitMQ
+   */
+  private $imagePath;
+
+  /**
+   * Initial method triggered by blocked call in mbc-image-processor.php. The $payload is the
+   * contents of the message being processed from the queue.
+   *
+   * @param array $payload
+   *   The contents of the queue entry
+   */
+  private function consumeImageProcessingQueue() {
+    
+    echo '- mbc-image-processor - MBC_ImageProcessingConsumer->consumeImageProcessingQueue() START', PHP_EOL;
+
+    parent::consumeQueue();
+    $this->setter($this->message);
+
+    $ip = new MBC_ImageProcessor($this->statHat, $this->toolbox, $this->settings);
+    $ip->process();
+    unset($ip);
+    
+    echo '- mbc-image-processor - MBC_ImageProcessingConsumer->consumeImageProcessingQueue() STOP', PHP_EOL;
+  }
+  
+  /**
+   * Sets values ofr processing based on contents of message from consumed queue.
+   */
+  private function setter($message) {
+
+    $imageMarkup = $message['merge_vars']['REPORTBACK_IMAGE_MARKUP'];
+    $imagePath = substr($imageMarkup, 10, strpos($imageMarkup, '.jpg?') + 5);
+    $this->imagePath = $imagePath;
+  }
+
+}

--- a/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
+++ b/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
@@ -3,7 +3,8 @@ namespace DoSomething\MBC_ImageProcessor;
 
 use DoSomething\StatHat\Client as StatHat;
 use DoSomething\MB_Toolbox\MB_Toolbox;
-use DoSomething\MMBC_ImageProcessor\MBC_ImageProcessor;
+use DoSomething\MBC_ImageProcessor\MBC_BaseConsumer;
+use DoSomething\MBC_ImageProcessor\MBC_ImageProcessor;
 
 /*
  * MBC_UserAPICampaignActivity.class.in: Used to process the transactionalQueue
@@ -46,6 +47,13 @@ class MBC_ImageProcessingConsumer extends MBC_BaseConsumer
     $imageMarkup = $message['merge_vars']['REPORTBACK_IMAGE_MARKUP'];
     $imagePath = substr($imageMarkup, 10, strpos($imageMarkup, '.jpg?') + 5);
     $this->imagePath = $imagePath;
+  }
+
+  /**
+   * Sets values for processing based on contents of message from consumed queue.
+   */
+  protected function process() {
+
   }
 
 }

--- a/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
+++ b/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
@@ -14,7 +14,7 @@ class MBC_ImageProcessingConsumer extends MBC_BaseConsumer
 {
 
   /**
-   * Message Broker connection to RabbitMQ
+   * The image and http path to request.
    */
   protected $imagePath;
 
@@ -25,35 +25,47 @@ class MBC_ImageProcessingConsumer extends MBC_BaseConsumer
    * @param array $payload
    *   The contents of the queue entry
    */
-  private function consumeImageProcessingQueue() {
-    
+  public function consumeImageProcessingQueue($message) {
+
     echo '- mbc-image-processor - MBC_ImageProcessingConsumer->consumeImageProcessingQueue() START', PHP_EOL;
 
-    parent::consumeQueue();
+    parent::consumeQueue($message);
     $this->setter($this->message);
 
-    $ip = new MBC_ImageProcessor($this->statHat, $this->toolbox, $this->settings);
-    $ip->process();
+    $ip = new MBC_ImageProcessor($this->messageBroker,  $this->statHat,  $this->toolbox, $this->settings);
+    $ip->setImagePath ($this->imagePath);
+    $ip->process($this->imagePath);
+
+    // Log processing of image
+    // $ip->log();
+
+    // Destructor?
     unset($ip);
-    
+
     echo '- mbc-image-processor - MBC_ImageProcessingConsumer->consumeImageProcessingQueue() STOP', PHP_EOL;
   }
-  
+
   /**
    * Sets values ofr processing based on contents of message from consumed queue.
+   *
+   * @param array $message
+   *  The payload of the message being processed.
    */
-  private function setter($message) {
+  protected function setter($message) {
 
     $imageMarkup = $message['merge_vars']['REPORTBACK_IMAGE_MARKUP'];
-    $imagePath = substr($imageMarkup, 10, strpos($imageMarkup, '.jpg?') + 5);
+    $imgTagOffset = 10;
+    $imagePath = substr($imageMarkup, $imgTagOffset, strpos($imageMarkup, '.jpg?') + 4 - $imgTagOffset);
     $this->imagePath = $imagePath;
   }
 
   /**
-   * Sets values for processing based on contents of message from consumed queue.
+   * Method to process image.
+   *
+   * @param array $payload
+   *   The contents of the queue entry
    */
   protected function process() {
-
   }
 
 }

--- a/mbc-image-processor/src/MBC_ImageProcessor.php
+++ b/mbc-image-processor/src/MBC_ImageProcessor.php
@@ -1,70 +1,15 @@
 <?php
+namespace DoSomething\MBC_ImageProcessor;
+
+use DoSomething\StatHat\Client as StatHat;
+use DoSomething\MB_Toolbox\MB_Toolbox;
+
 /*
  * MBC_UserAPICampaignActivity.class.in: Used to process the transactionalQueue
  * entries that match the campaign.*.* binding.
  */
-
-use DoSomething\MB_Toolbox\MB_Toolbox;
-use DoSomething\MBStatTracker\StatHat;
-
 class MBC_ImageProcessor
 {
-
-  /**
-   * Message Broker connection to RabbitMQ
-   */
-  private $messageBroker;
-
-  /**
-   * Setting from external services - Mailchimp.
-   *
-   * @var array
-   */
-  private $settings;
-
-  /**
-   * Setting from external services - Mailchimp.
-   *
-   * @var array
-   */
-  private $statHat;
-
-  /**
-   * Constructor for MBC_TransactionalEmail
-   *
-   * @param array $settings
-   *   Settings from external services - StatHat
-   */
-  public function __construct($messageBroker, $settings) {
-
-    $this->messageBroker = $messageBroker;
-    $this->settings = $settings;
-
-    $this->toolbox = new MB_Toolbox($settings);
-    $this->statHat = new StatHat($settings['stathat_ez_key'], 'mbc-a1-startHere:');
-    $this->statHat->setIsProduction(isset($settings['use_stathat_tracking']) ? $settings['use_stathat_tracking'] : FALSE);
-  }
-
-  /**
-   * Initial method triggered by blocked call in mbc-image-processor.php. The $payload is the
-   * contents of the message being processed from the queue.
-   *
-   * @param array $payload
-   *   The contents of the queue entry
-   */
-  public function consumeImageProcessingQueue($payload) {
-    
-    echo '------- mbc-image-processor - consumeImageProcessingQueue() START -------', PHP_EOL;
-
-    $payloadDetails = unserialize($payload->body);
-    
-    // Only process queue entries that have image details
-    if ($payloadDetails['campaign_reportback'] && isset($payloadDetails['image_markup'])) {
-      $this->processImage($payloadDetails['image_markup']);
-    }
-    
-    echo '------- mbc-image-processor - consumeImageProcessingQueue() START -------', PHP_EOL;
-  }
 
   /**
    * Method to process image details. Make requests to trigger image cache processing on the Drupal site.
@@ -72,12 +17,7 @@ class MBC_ImageProcessor
    * @param array $payload
    *   The contents of the queue entry
    */
-  public function processImage($imageMarkup) {
-  
-    // Some processing of the message payload
-    $post = array(
-      'email' => '??',
-    );
+  public function process() {
 
     // An example cURL POST to the Message Broker User API (mb-user-api) to store peristant
     // Message Broker relivant data using the MB_Toolbox library.
@@ -86,8 +26,7 @@ class MBC_ImageProcessor
     if ($port != 0) {
       $curlUrl .= ":$port";
     }
-    $curlUrl .= '/user';
-    $result = $this->toolbox->curlPOST($curlUrl, $post);
+    $result = $this->toolbox->curlGETImage($curlUrl, $post);
 
     // Log consumer activity to StatHat for monitoring
     $this->statHat->clearAddedStatNames();

--- a/mbc-image-processor/src/MBC_ImageProcessor.php
+++ b/mbc-image-processor/src/MBC_ImageProcessor.php
@@ -35,16 +35,15 @@ class MBC_ImageProcessor extends MBC_ImageProcessingConsumer
     $result = MB_Toolbox_cURL::curlGETImage($this->imagePath);
 
     // Log consumer activity to StatHat for monitoring
-    $this->statHat->clearAddedStatNames();
     if ($result[1] == 200) {
-      $this->statHat->addStatName('success');
+      $this->statHat->ezCount('mbc-image-processor: MBC_ImageProcessor->process()', 1);
     }
     else {
       echo '** FAILED to GET ' . $this->imagePath  . ' image to trigger image style builds.', PHP_EOL;
-      echo '------- mbc-a1-startHere - MBC_A1_StartHere->startHere: $post: ' . print_r($post, TRUE) . ' - ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
-      $this->statHat->addStatName('update failed');
+      echo '------- mbc-image-processor - MBC_ImageProcessor->process(: $imagePath: ' . $this->imagePath . ' - ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
+      $this->statHat->ezCount('mbc-image-processor: MBC_ImageProcessor->process() FAILED', 1);
     }
-    $this->statHat->reportCount(1);
+
   }
 
 }

--- a/mbc-image-processor/src/MBC_ImageProcessor.php
+++ b/mbc-image-processor/src/MBC_ImageProcessor.php
@@ -3,6 +3,7 @@ namespace DoSomething\MBC_ImageProcessor;
 
 use DoSomething\StatHat\Client as StatHat;
 use DoSomething\MB_Toolbox\MB_Toolbox;
+use DoSomething\MB_Toolbox\MB_Toolbox_cURL;
 
 /*
  * MBC_UserAPICampaignActivity.class.in: Used to process the transactionalQueue
@@ -12,12 +13,24 @@ class MBC_ImageProcessor extends MBC_ImageProcessingConsumer
 {
 
   /**
-   * Method to process image details. Make requests to trigger image cache processing on the Drupal site.
-   *
-   * @param array $payload
-   *   The contents of the queue entry
+   * The image and http path to request.
    */
-  public function process() {
+  protected $imagePath;
+
+  /**
+   * Sets values ofr processing based on contents of message from consumed queue.
+   *
+   * @param array $message
+   *  The payload of the message being processed.
+   */
+  protected function setImagePath($imagePath) {
+    $this->imagePath = $imagePath;
+  }
+
+  /**
+   * Method to process image details. Make requests to trigger image cache processing on the Drupal site.
+   */
+  protected function process() {
 
     $result = MB_Toolbox_cURL::curlGETImage($this->imagePath);
 
@@ -32,7 +45,6 @@ class MBC_ImageProcessor extends MBC_ImageProcessingConsumer
       $this->statHat->addStatName('update failed');
     }
     $this->statHat->reportCount(1);
-    
   }
 
 }

--- a/mbc-image-processor/src/MBC_ImageProcessor.php
+++ b/mbc-image-processor/src/MBC_ImageProcessor.php
@@ -8,7 +8,7 @@ use DoSomething\MB_Toolbox\MB_Toolbox;
  * MBC_UserAPICampaignActivity.class.in: Used to process the transactionalQueue
  * entries that match the campaign.*.* binding.
  */
-class MBC_ImageProcessor
+class MBC_ImageProcessor extends MBC_ImageProcessingConsumer
 {
 
   /**
@@ -27,7 +27,7 @@ class MBC_ImageProcessor
       $this->statHat->addStatName('success');
     }
     else {
-      echo '** FAILED to update ?? for email: ' . $post['email'], PHP_EOL;
+      echo '** FAILED to GET ' . $this->imagePath  . ' image to trigger image style builds.', PHP_EOL;
       echo '------- mbc-a1-startHere - MBC_A1_StartHere->startHere: $post: ' . print_r($post, TRUE) . ' - ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
       $this->statHat->addStatName('update failed');
     }

--- a/mbc-image-processor/src/MBC_ImageProcessor.php
+++ b/mbc-image-processor/src/MBC_ImageProcessor.php
@@ -19,14 +19,7 @@ class MBC_ImageProcessor
    */
   public function process() {
 
-    // An example cURL POST to the Message Broker User API (mb-user-api) to store peristant
-    // Message Broker relivant data using the MB_Toolbox library.
-    $curlUrl = $this->settings['ds_user_api_host'];
-    $port = $this->settings['ds_user_api_port'];
-    if ($port != 0) {
-      $curlUrl .= ":$port";
-    }
-    $result = $this->toolbox->curlGETImage($curlUrl, $post);
+    $result = MB_Toolbox_cURL::curlGETImage($this->imagePath);
 
     // Log consumer activity to StatHat for monitoring
     $this->statHat->clearAddedStatNames();


### PR DESCRIPTION
Fixes #7 

Consumer for `imageProcessingQueue`. Queue entries are produced by the Drupal application when a user submits a reportback image. Consumer sends http request to image URL to trigger Drupal image style generation. The result is off loading image styles generation asynchronously resulting in a faster / better user experience.

_To Test_*:
- Create test entry in `imageProcessingQueue` by submitting a report back on the Drupal site or making a. test message entry in queue. Sample message payload:

```
a:9:{s:8:"activity";s:19:"campaign_reportback";s:5:"email";s:11:xyz@xyz.com";s:3:"uid";s:7:"1234567";s:10:"merge_vars";a:7:{s:12:"MEMBER_COUNT";s:11:"3.8 million";s:5:"FNAME";s:3:"Joe";s:14:"CAMPAIGN_TITLE";s:12:"1 in 3 of Us";s:11:"IMPACT_VERB";s:6:"shared";s:13:"IMPACT_NUMBER";s:1:"2";s:11:"IMPACT_NOUN";s:4:"kits";s:23:"REPORTBACK_IMAGE_MARKUP";s:180:"<img src="https://dosomething-a.akamaihd.net/sites/default/files/styles/300x300/public/reportbacks/5275/uid_2734379-nid_5275-0.png?itok=-rvWaOqo" width="300" height="300" alt="" />";}s:14:"email_template";s:25:"mb-campaign-reportback-US";s:8:"event_id";s:4:"5275";s:10:"email_tags";a:1:{i:0;s:26:"drupal_campaign_reportback";}s:18:"activity_timestamp";i:1432087926;s:14:"application_id";s:2:"US";}
```
- queue entries are consumed immediately as mbc-image-processor runs as a daemon process.
- will result in image generation for each of the image styles defined in the Drupal application.
