### PR TITLE
Issue9 throttling

### DIFF
--- a/mbc-image-processor/mbc-image-processor.php
+++ b/mbc-image-processor/mbc-image-processor.php
@@ -27,7 +27,6 @@ $sh = new StatHat([
 ]);
 $tb = new MB_Toolbox($settings);
 
-
 // Kick off - block, waiting for messages in queue
 echo '------- mbc-logging-gateway START - ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;
 $mb->consumeMessage(array(new MBC_ImageProcessingConsumer($mb, $sh, $tb, $settings), 'consumeImageProcessingQueue'));

--- a/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
+++ b/mbc-image-processor/src/MBC_ImageProcessingConsumer.php
@@ -29,6 +29,9 @@ class MBC_ImageProcessingConsumer extends MBC_BaseConsumer
 
     echo '- mbc-image-processor - MBC_ImageProcessingConsumer->consumeImageProcessingQueue() START', PHP_EOL;
 
+    // Limit the message rate per second to prevent overloading the Drupal app with image requeuests.
+    $this->throttle(5);
+
     parent::consumeQueue($message);
     $this->setter($this->message);
 


### PR DESCRIPTION
Fixes #9 

Adds throttling method to base consumer class. Throttling can be used to limit the rate that the consumer application processes messages. Limiting the process rate helps to prevent overloading of applications that the consumer accesses.
