### PR TITLE
Support transaction logging

### DIFF
--- a/mbc-logging-gateway/mbc-logging-gateway.config.inc
+++ b/mbc-logging-gateway/mbc-logging-gateway.config.inc
@@ -1,6 +1,6 @@
 <?php
 /**
- * Message Broker configuration settings for mbc-import-logging
+ * Message Broker configuration settings for mbc-logging-gateway
  */
 
 

--- a/mbc-logging-gateway/mbc-logging-gateway.php
+++ b/mbc-logging-gateway/mbc-logging-gateway.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * mbc-import-logging.php
+ * mbc-logging-gateway
  *
  * Collect user import activity from the userImportExistingLoggingQueue. Update
  * the LoggingAPI / database with import activity via mb-logging.

--- a/mbc-logging-gateway/src/MBC_LoggingGateway.php
+++ b/mbc-logging-gateway/src/MBC_LoggingGateway.php
@@ -101,7 +101,7 @@ class MBC_LoggingGateway
         break;
 
       default:
-        echo '- ERROR - Payload missing key values: ' . print_r($payloadDetails, TRUE), PHP_EOL;
+        echo '- ERROR - Payload missing log-type value: ' . print_r($payloadDetails, TRUE), PHP_EOL;
         $endpoint = NULL;
         $this->messageBroker->sendAck($payload);
 

--- a/mbc-logging-gateway/src/MBC_LoggingGateway.php
+++ b/mbc-logging-gateway/src/MBC_LoggingGateway.php
@@ -95,6 +95,11 @@ class MBC_LoggingGateway
 
         break;
 
+      case 'transactional':
+        list($endPoint, $cURLparameters, $post) = $this->logTransactional($payloadDetails);
+
+        break;
+
       default:
         echo '- ERROR - Payload missing key values: ' . print_r($payloadDetails, TRUE), PHP_EOL;
         $endpoint = NULL;
@@ -221,6 +226,37 @@ class MBC_LoggingGateway
 
     if (isset($payloadDetails['activity_details'])) {
       $post['activity_details'] = serialize($payloadDetails['activity_details']);
+    }
+
+    return array($endpoint, $cURLparameters, $post);
+  }
+
+  /**
+   * logTransactional: Format values for "transactional" log entry.
+   *
+   * @param array $payloadDetails
+   *   Values submitted in activity message to be processed to create "vote" log entry.
+   *
+   * @return string $endpoint
+   *   The cURUL POST URL to mb-logging-api.
+   * @return array $cURLparameters
+   *   The parameters to include in the cURL POST.
+   * @return array $post
+   *   Post values for the cURL POST.
+   */
+  public function logTransactional($payloadDetails) {
+
+    $endpoint = '/user/transactional';
+    $cURLparameters['email'] = $payloadDetails['email'];
+    $cURLparameters['activity'] = $payloadDetails['activity'];
+
+    $post = array();
+    $post['source'] = $payloadDetails['source'];
+    $post['activity_timestamp'] = $payloadDetails['activity_timestamp'];
+    $post['message'] = serialize($payloadDetails);
+
+    if (isset($payloadDetails['mobile'])) {
+      $post['mobile'] = $payloadDetails['mobile'];
     }
 
     return array($endpoint, $cURLparameters, $post);


### PR DESCRIPTION
Fixes #13 

Adds support for "`transactional` event logging.

Messages in the `loggingQueue` will be sent to the `loggingGatewayQueue` with the `log-type` = `transactional`. Add a method to format a submission to the `/api/v1/user/transactional` endpoint of the `mb-logging-api`.
