### PR TITLE
Issue47 shim message

### DIFF
--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -197,13 +197,19 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
     // Build transactional requests for each of the users
     foreach ($this->users as $address => $messageDetails) {
 
-      if ($messageDetails['last_transaction_stamp'] < (time() - self::DIGEST_WINDOW)) {
+      if (isset($messageDetails['last_transaction_stamp']) && $messageDetails['last_transaction_stamp'] < (time() - self::DIGEST_WINDOW)) {
 
-        // Toggle between message services depending on communication medium - eMail vs SMS vs OTT
-        $medium = $this->whatMedium($address);
-        $messageDetails['campaignsMarkup'] = $this->mbMessageServices[$medium]->generateCampaignsMarkup($messageDetails['campaigns']);
-        $message = $this->mbMessageServices[$medium]->generateMessage($address, $messageDetails);
-        $this->mbMessageServices[$medium]->dispatchMessage($message);
+        if (count($messageDetails['campaigns']) > 1) {
+          // Toggle between message services depending on communication medium - eMail vs SMS vs OTT
+          $medium = $this->whatMedium($address);
+          $messageDetails['campaignsMarkup'] = $this->mbMessageServices[$medium]->generateCampaignsMarkup($messageDetails['campaigns']);
+          $message = $this->mbMessageServices[$medium]->generateMessage($address, $messageDetails);
+          $this->mbMessageServices[$medium]->dispatchDigestMessage($message);
+        }
+        else {
+          $message = $this->mbMessageServices[$medium]->generateSingleMessage($address, $messageDetails);
+          $this->mbMessageServices[$medium]->dispatchSingleMessage($message);
+        }
         unset($this->users[$address]);
 
       }

--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -133,9 +133,10 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
    */
   protected function canProcess() {
 
-    if (empty($this->message['email'])) {
+    if (empty($this->message['email']) && empty($this->message['mobile']) && empty($this->message['ott'])) {
       return false;
     }
+
     if (empty($this->message['activity'])) {
       return false;
     }

--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -19,7 +19,8 @@ use \Exception;
 class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
 {
 
-  const DIGEST_WINDOW = 300;
+  const TRANSACTIONAL_DIGEST_WINDOW = 5;
+  const TRANSACTIONAL_DIGEST_CYCLE = 2;
 
   /**
    * mb-logging-api configuration settings.
@@ -48,6 +49,13 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
   private $mbLoggingAPIConfig;
 
   /**
+   * The timestamp of the last time the list of user transactions was processed.
+   *
+   * @var init $lastProcessed
+   */
+  private $lastProcessed;
+
+  /**
    * Constructor for MBC_LoggingGateway
    *
    * @param string $targetMBconfig
@@ -63,6 +71,7 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
     $this->mbMessageServices['ott'] = new MB_Toolbox_FacebookMessengerService();
 
     $this->mbLoggingAPIConfig = $this->mbConfig->getProperty('mb_logging_api_config');
+    $this->lastProcessed = time();
   }
 
   /**
@@ -81,16 +90,17 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
       if ($this->canProcess()) {
         parent::logConsumption(['email', 'event_id']);
         $this->setter($this->message);
+        $this->messageBroker->sendAck($this->message['payload']);
       }
-      elseif ($this->message['log-type'] == 'shim') {
+      elseif (isset($this->message['log-type']) && $this->message['log-type'] == 'shim') {
         echo '* Shim message encounter... time to sleep.', PHP_EOL;
         sleep(self::SHIM_SLEEP);
         $this->processShim();
       }
       else {
-        echo '- ' . $this->message['log-type'] . ' can\'t be processed, sending to deadLetterQueue.', PHP_EOL;
+        echo '- Message can\'t be processed, sending to deadLetterQueue.', PHP_EOL;
         $this->statHat->ezCount('mbc-transactional-digest: MBC_LoggingGateway_Consumer: Exception: deadLetter', 1);
-        parent::deadLetter($this->message, 'MBC_LoggingGateway_Consumer->consumeLoggingGatewayQueue() Generation Error', $e->getMessage());
+        // parent::deadLetter($this->message, 'MBC_LoggingGateway_Consumer->consumeLoggingGatewayQueue() Generation Error');
 
       }
     }
@@ -103,7 +113,7 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
     try {
       if ($this->timeToProcess()) {
         $this->process();
-        $this->messageBroker->sendAck($this->message['payload']);
+        $this->lastProcessed = time();
       }
     }
     catch(Exception $e) {
@@ -182,9 +192,11 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
     }
     if (isset($message['mobile']) && empty($this->users[$message['mobile']]->campaigns[$message['event_id']])) {
       $this->users[$message['mobile']]['campaigns'][$message['event_id']] = $this->campaigns[$message['event_id']]->markup['sms'];
+      $this->users[$message['mobile']]['last_transaction_stamp'] = time();
     }
     if (isset($message['ott']) && empty($this->users[$message['ott']]->campaigns[$message['event_id']])) {
       $this->users[$message['ott']]['campaigns'][$message['event_id']] = $this->campaigns[$message['event_id']]->markup['ott'];
+      $this->users[$message['ott']]['last_transaction_stamp'] = time();
     }
 
   }
@@ -197,13 +209,15 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
     // Build transactional requests for each of the users
     foreach ($this->users as $address => $messageDetails) {
 
-      if (isset($messageDetails['last_transaction_stamp']) && $messageDetails['last_transaction_stamp'] < (time() - self::DIGEST_WINDOW)) {
+      if (isset($messageDetails['last_transaction_stamp']) && $messageDetails['last_transaction_stamp'] < (time() - self::TRANSACTIONAL_DIGEST_WINDOW)) {
 
+        // Digest messages are composed of at least two signups in the DIGEST_WINDOW. If only one campaign signup, \
+        // send message to transactionalQueue to send standard campaign signup message.
+        $medium = $this->whatMedium($address);
         if (count($messageDetails['campaigns']) > 1) {
           // Toggle between message services depending on communication medium - eMail vs SMS vs OTT
-          $medium = $this->whatMedium($address);
           $messageDetails['campaignsMarkup'] = $this->mbMessageServices[$medium]->generateCampaignsMarkup($messageDetails['campaigns']);
-          $message = $this->mbMessageServices[$medium]->generateMessage($address, $messageDetails);
+          $message = $this->mbMessageServices[$medium]->generateDigestMessage($address, $messageDetails);
           $this->mbMessageServices[$medium]->dispatchDigestMessage($message);
         }
         else {
@@ -285,9 +299,10 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
    */
   public function timeToProcess() {
 
-    // $queuedMessages = parent::queueStatus('transactionalDigestQueue');
-
-    return true;
+    if (isset($this->lastProcessed) && $this->lastProcessed + self::TRANSACTIONAL_DIGEST_CYCLE < time()) {
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -152,6 +152,11 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
       throw new Exception($message);
     }
 
+    // TEST MODE
+    if (strpos($this->message['email'], '@dosomething.org') === false) {
+      return false;
+    }
+
     return true;
   }
 

--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -299,7 +299,7 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
    */
   public function timeToProcess() {
 
-    if (isset($this->lastProcessed) && $this->lastProcessed + self::TRANSACTIONAL_DIGEST_CYCLE < time()) {
+    if (($this->lastProcessed + self::TRANSACTIONAL_DIGEST_CYCLE) < time()) {
       return true;
     }
     return false;

--- a/mbc-transactional-digest/src/MB_Toolbox_BaseService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_BaseService.php
@@ -72,22 +72,40 @@ abstract class MB_Toolbox_BaseService
   }
 
  /**
-  * generateMarkup(): Generate message values based on target service.
+  * generateMessage(): Generate message values based on target service.
   *
   * @param string $address
   *   The specific user address of the medium the service communicates with.
   * @param array $messageDetails
   *   Settings used to construct the message contents.
   */
-  abstract function generateMessage($address, $messageDetails);
- 
+  abstract function generateDigestMessage($address, $messageDetails);
+
  /**
-  * dispatchMessage(): Send message to transactional queue.
+  * dispatchDigestMessage(): Send message to transactional queue.
   *
   * @param array $message
   *   The values to send as a message to the transactional queue.
   */
-  abstract function dispatchMessage($message);
+  abstract function dispatchDigestMessage($message);
+
+ /**
+  * generateSingleMessage(): Generate message values based on target service.
+  *
+  * @param string $address
+  *   The specific user address of the medium the service communicates with.
+  * @param array $messageDetails
+  *   Settings used to construct the message contents.
+  */
+  abstract function generateSingleMessage($address, $messageDetails);
+
+ /**
+  * dispatchSingleMessage(): Send message to transactional queue.
+  *
+  * @param array $message
+  *   The values to send as a message to the transactional queue.
+  */
+  abstract function dispatchSingleMessage($message);
 
   /**
    * getTeamplate(): Gather base template values by loading include (inc) file.

--- a/mbc-transactional-digest/src/MB_Toolbox_FacebookMessengerService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_FacebookMessengerService.php
@@ -7,6 +7,8 @@
  */
 
 namespace DoSomething\MBC_TransactionalDigest;
+
+use \Exception;
  
 /**
  * The MB_Toolbox_FacebookMessengerService class. A collection of functionality related to Over

--- a/mbc-transactional-digest/src/MB_Toolbox_FacebookMessengerService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_FacebookMessengerService.php
@@ -103,7 +103,7 @@ class MB_Toolbox_FacebookMessengerService extends MB_Toolbox_BaseService
  }
 
  /**
-  * generateMessage(): Generate message values based on Facebook Messenger requirements.
+  * generateDigestMessage(): Generate message values based on Facebook Messenger requirements.
   *
   * @param string $address
   *   The specific user address of the medium the service communicates with.
@@ -113,7 +113,7 @@ class MB_Toolbox_FacebookMessengerService extends MB_Toolbox_BaseService
   * @return array $message
   *   Formatted message in format required by the service.
   */
-  public function generateMessage($address, $messageDetails) {
+  public function generateDigestMessage($address, $messageDetails) {
 
     $message['contents'] = 'FACEBOOK MESSENGER MESSAGE';
 
@@ -121,13 +121,36 @@ class MB_Toolbox_FacebookMessengerService extends MB_Toolbox_BaseService
   }
 
  /**
-  * dispatchMessage(): Send message to Twilio to trigger sending transactional Facebook Messenger message.
+  * dispatchDigestMessage(): Send message to Twilio to trigger sending transactional Facebook Messenger message.
   *
   * @param array $message
   *   Values to create message for processing in ottTransactionalQueue.
   */
-  public function dispatchMessage($message) {
+  public function dispatchDigestMessage($message) {
 
  }
+
+ /**
+  * generateSingleMessages():
+  *
+  * @param array $message
+  *   Values to create message for processing in transactionalQueue.
+  */
+  public function generateSingleMessage($address, $messageDetails) {
+
+    // $this->transactionQueue->publish($message, 'user.registration.transactional');
+  }
+
+ /**
+  * dispatchSingleMessages(): Send message to transactionalQueue to trigger sending transactional email message
+  * in signle campaign signup format.
+  *
+  * @param array $message
+  *   Values to create message for processing in transactionalQueue.
+  */
+  public function dispatchSingleMessage($payload) {
+
+    // $this->transactionQueue->publish($message, 'user.registration.transactional');
+  }
 
 }

--- a/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
@@ -216,44 +216,6 @@ class MB_Toolbox_MandrillService extends MB_Toolbox_BaseService
 
     $message = json_encode($payload);
     $this->transactionQueue->publish($message, 'user.registration.transactional');
-
   }
 
 }
-
-/*
-(
-    [activity] => campaign_signup
-    [email] => xxx@yahoo.com
-    [uid] => 3887635
-    [merge_vars] => Array
-        (
-            [MEMBER_COUNT] => 5.3 million
-            [FNAME] => Emily
-            [CAMPAIGN_TITLE] => Bubble Breaks
-            [CAMPAIGN_LINK] => https://www.dosomething.org/campaigns/bubble-breaks?source=node/1524
-            [CALL_TO_ACTION] => Create homemade bubble blowing kits for kids at a family shelter. 
-            [STEP_ONE] => Create and Decorate!
-            [STEP_TWO] => Snap a Pic
-            [STEP_THREE] => Drop It Off
-        )
-
-    [user_country] => US
-    [user_language] => en
-    [campaign_language] => en-global
-    [campaign_country] => global
-    [email_template] => mb-campaign-signup-US
-    [subscribed] => 1
-    [event_id] => 1524
-    [email_tags] => Array
-        (
-            [0] => 1524
-            [1] => drupal_campaign_signup
-        )
-
-    [mobile] => 1234567890
-    [activity_timestamp] => 1463499802
-    [application_id] => US
-)
-*/
-

--- a/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
@@ -185,13 +185,14 @@ class MB_Toolbox_MandrillService extends MB_Toolbox_BaseService
   *
   *   Note: There's now support for "long SMS messages" of 2500 characters.
   */
-  public function generateMessage($address, $messageDetails) {
+  public function generateDigestMessage($address, $messageDetails) {
 
     $template = 'mb-transactional-digest-v0-0-1';
     $mergeVars = $this->getMergeVars($messageDetails['campaignsMarkup'], $messageDetails['merge_vars']);
     $tags = $this->getTransactionalDigestMessageTags();
 
     $message = [
+      'log-type' => 'transactional',
       'activity' => 'campaign_signup_digest',
       'email_template' => $template,
       'email' => $address,
@@ -205,17 +206,39 @@ class MB_Toolbox_MandrillService extends MB_Toolbox_BaseService
     return $message;
   }
 
-
  /**
-  * dispatchMessages(): Send message to transactionalQueue to trigger sending transactional email messages.
+  * dispatchMessages(): Send message to transactionalQueue to trigger sending transactional email message.
   *
   * @param array $message
   *   Values to create message for processing in transactionalQueue.
   */
-  public function dispatchMessage($payload) {
+  public function dispatchDigestMessage($payload) {
 
     $message = json_encode($payload);
-    $this->transactionQueue->publish($message, 'user.registration.transactional');
+    // $this->transactionQueue->publish($message, 'campaigns.signup-digest.transactional');
+  }
+
+ /**
+  * generateSingleMessages():
+  *
+  * @param array $message
+  *   Values to create message for processing in transactionalQueue.
+  */
+  public function generateSingleMessage($address, $messageDetails) {
+
+    // $this->transactionQueue->publish($message, 'user.registration.transactional');
+  }
+
+ /**
+  * dispatchSingleMessages(): Send message to transactionalQueue to trigger sending transactional email message
+  * in signle campaign signup format.
+  *
+  * @param array $message
+  *   Values to create message for processing in transactionalQueue.
+  */
+  public function dispatchSingleMessage($payload) {
+
+    // $this->transactionQueue->publish($message, 'user.registration.transactional');
   }
 
 }

--- a/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
@@ -9,6 +9,8 @@
 
 namespace DoSomething\MBC_TransactionalDigest;
 
+use \Exception;
+
 /**
  * The MB_Toolbox_MandrillService class. A collection of functionality related to email and the
  * Mandrill service.

--- a/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_MandrillService.php
@@ -228,7 +228,7 @@ class MB_Toolbox_MandrillService extends MB_Toolbox_BaseService
   */
   public function generateSingleMessage($address, $messageDetails) {
 
-    // $this->transactionQueue->publish($message, 'user.registration.transactional');
+    $this->transactionQueue->publish($message, 'campaign.signup-digest.transactional');
   }
 
  /**
@@ -240,7 +240,7 @@ class MB_Toolbox_MandrillService extends MB_Toolbox_BaseService
   */
   public function dispatchSingleMessage($payload) {
 
-    // $this->transactionQueue->publish($message, 'user.registration.transactional');
+    $this->transactionQueue->publish($message, 'campaign.signup.transactional');
   }
 
 }

--- a/mbc-transactional-digest/src/MB_Toolbox_MobileCommonsService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_MobileCommonsService.php
@@ -104,7 +104,7 @@ class MB_Toolbox_MobileCommonsService extends MB_Toolbox_BaseService
   }
 
  /**
-  * generateMessage(): Generate message values based on Mobile Commons send_message() requirements.
+  * generateDigestMessage(): Generate message values based on Mobile Commons send_message() requirements.
   *
   * @param string $address
   *   The specific user address of the medium the service communicates with.
@@ -122,7 +122,7 @@ class MB_Toolbox_MobileCommonsService extends MB_Toolbox_BaseService
   * @return array $message
   *   Formatted message in format required by the service.
   */
-  public function generateMessage($address, $campaignsMarkup) {
+  public function generateDigestMessage($address, $campaignsMarkup) {
 
     $message['contents'] = 'MOBILE COMMONS MESSAGE';
 
@@ -136,7 +136,7 @@ class MB_Toolbox_MobileCommonsService extends MB_Toolbox_BaseService
   }
 
  /**
-  * dispatchMessage(): Send message to mobileCommonsQueue to trigger sending transactional Mobile Commons message.
+  * dispatchDigestMessage(): Send message to mobileCommonsQueue to trigger sending transactional Mobile Commons message.
   *
   *   Send SMS Message: https://secure.mcommons.com/api/send_message
   *   https://mobilecommons.zendesk.com/hc/en-us/articles/202052534-REST-API#SendSMSMessage.
@@ -144,50 +144,31 @@ class MB_Toolbox_MobileCommonsService extends MB_Toolbox_BaseService
   * @param array $message
   *   Values to create message for processing in transactionalQueue.
   */
-  public function dispatchMessage($message) {
+  public function dispatchDigestMessage($message) {
 
   }
 
+ /**
+  * generateSingleMessages():
+  *
+  * @param array $message
+  *   Values to create message for processing in transactionalQueue.
+  */
+  public function generateSingleMessage($address, $messageDetails) {
+
+    // $this->transactionQueue->publish($message, 'user.registration.transactional');
+  }
+
+ /**
+  * dispatchSingleMessages(): Send message to transactionalQueue to trigger sending transactional email message
+  * in signle campaign signup format.
+  *
+  * @param array $message
+  *   Values to create message for processing in transactionalQueue.
+  */
+  public function dispatchSingleMessage($payload) {
+
+    // $this->transactionQueue->publish($message, 'user.registration.transactional');
+  }
+
 }
-
-/*
-
-(
-    [activity] => campaign_signup
-    [email] => xxx@gmail.com
-    [uid] => 3404728
-    [merge_vars] => Array
-        (
-            [MEMBER_COUNT] => 5.3 million
-            [FNAME] => Jonice
-            [CAMPAIGN_TITLE] => World Recycle Week: Close The Loop 
-            [CAMPAIGN_LINK] => https://www.dosomething.org/us/campaigns/world-recycle-week-close-loop-0?source=node/362
-            [CALL_TO_ACTION] => Recycle old or worn-out clothes to help our planet.
-            [STEP_ONE] => Run Your Drive!
-            [STEP_TWO] => Snap a Pic
-            [STEP_THREE] => Drop It Off
-        )
-
-    [user_country] => US
-    [user_language] => en
-    [campaign_language] => en
-    [campaign_country] => US
-    [email_template] => mb-campaign-signup-US
-    [subscribed] => 1
-    [event_id] => 362
-    [email_tags] => Array
-        (
-            [0] => 362
-            [1] => drupal_campaign_signup
-        )
-
-    [mailchimp_list_id] => 8e7844f6dd
-    [mailchimp_grouping_id] => 10641
-    [mailchimp_group_name] => ComebackClothes2015
-    [mobile] => 1234567890
-    [mc_opt_in_path_id] => 203359
-    [activity_timestamp] => 1463500108
-    [application_id] => US
-)
-
-*/

--- a/mbc-transactional-digest/src/MB_Toolbox_MobileCommonsService.php
+++ b/mbc-transactional-digest/src/MB_Toolbox_MobileCommonsService.php
@@ -9,6 +9,8 @@
 
 namespace DoSomething\MBC_TransactionalDigest;
 
+use \Exception;
+
 /**
  * The MB_Toolbox_MobileCommonsService class. A collection of functionality related to SMS and the
  * Mobile Commons service.
@@ -36,8 +38,8 @@ class MB_Toolbox_MobileCommonsService extends MB_Toolbox_BaseService
     parent::__construct();
     $this->transactionQueue = $this->mbConfig->getProperty('transactionalSMSQueue');
 
-    $this->campaignMarkup = parent::getTemplate('campaign-markup.mandrill.inc');
-    $this->campaignTempateDivider = parent::getTemplate('campaign-divider-markup.mandrill.inc');
+    $this->campaignMarkup = parent::getTemplate('campaign-markup.mobile-commons.inc');
+    $this->campaignTempateDivider = parent::getTemplate('campaign-divider-markup.mobile-commons.inc');
   }
 
   /**

--- a/mbc-transactional-digest/templates/campaign-divider-markup.facebook-messenger.inc
+++ b/mbc-transactional-digest/templates/campaign-divider-markup.facebook-messenger.inc
@@ -1,15 +1,2 @@
-												  <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock">
-                            <tbody class="mcnDividerBlockOuter">
-                              <tr>
-                                <td class="mcnDividerBlockInner" style="padding-bottom: 18px; padding-top: 18px;">
-                                  <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-top-width: 1px;border-top-style: solid;border-top-color: #999999;">
-                                    <tbody><tr>
-                                      <td>
-                                        <span></span>
-                                      </td>
-                                    </tr></tbody>
-																	</table>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
+
+--------------

--- a/mbc-transactional-digest/templates/campaign-divider-markup.mobile-commons.inc
+++ b/mbc-transactional-digest/templates/campaign-divider-markup.mobile-commons.inc
@@ -1,15 +1,2 @@
-												  <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock">
-                            <tbody class="mcnDividerBlockOuter">
-                              <tr>
-                                <td class="mcnDividerBlockInner" style="padding-bottom: 18px; padding-top: 18px;">
-                                  <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-top-width: 1px;border-top-style: solid;border-top-color: #999999;">
-                                    <tbody><tr>
-                                      <td>
-                                        <span></span>
-                                      </td>
-                                    </tr></tbody>
-																	</table>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
+
+--------------

--- a/mbc-transactional-digest/templates/campaign-markup.facebook-messenger.inc
+++ b/mbc-transactional-digest/templates/campaign-markup.facebook-messenger.inc
@@ -1,37 +1,6 @@
+*|CAMPAIGN_TITLE|*
+*|CALL_TO_ACTION|*
+*|TIP_TITLE|* - *|DURING_TIP|*
 
-<table border="0" cellpadding="0" cellspacing="0" class="mcnCaptionRightContentOuter" width="100%">
-  <tbody><tr>
-    <td valign="top" class="mcnCaptionRightContentInner" style="padding:0 9px 0 0 ;">
-      <table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnCaptionRightImageContentContainer">
-        <tbody><tr>
-          <td class="mcnCaptionRightImageContent" valign="top">
-            <a href="*|CAMPAIGN_LINK|*" title="" class="" target="_blank">
-              <img src="*|CAMPAIGN_IMAGE_URL|*" class="mcnImage">
-            </a>
-          </td>
-        </tr></tbody>
-      </table>
-      <table class="mcnCaptionRightTextContentContainer" align="right" border="0" cellpadding="0" cellspacing="0" width="244" style="padding-left: 8px;">
-        <tbody><tr>
-          <td valign="top" class="mcnTextContent">
-            <center>
-              <h2 class="null" dir="ltr" style="text-align: left;"><span style="font-size:24px">*|CAMPAIGN_TITLE|*</span></h2>
-              <h3 class="null" dir="ltr" style="text-align: left;"><font size="4">*|CALL_TO_ACTION|*</font></h3>
-              <p dir="ltr" style="text-align: left;"><strong>*|TIP_TITLE|*</strong>&nbsp;*|DURING_TIP|*</p>
-            </center>
-            <center>
-              <table border="0" cellpadding="0" cellspacing="0" class="emailButton" style="border-radius:3px; background-color:#23b7fb;" mc:edit="buttonlink">
-                <tbody>
-                  <tr>
-                    <td align="center" class="emailButtonContent" style="padding-top:16px; padding-right:16px; padding-bottom:16px; padding-left:16px;" valign="middle"><a href="*|CAMPAIGN_LINK|*" style="color:#FFFFFF; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; text-decoration:none;" target="_blank">DID IT? PROVE IT!</a>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </center>
-          </td>
-        </tr></tbody>
-      </table>
-    </td>
-  </tr></tbody>
-</table>
+DID IT? PROVE IT!
+*|CAMPAIGN_LINK|*

--- a/mbc-transactional-digest/templates/campaign-markup.mobile-commons.inc
+++ b/mbc-transactional-digest/templates/campaign-markup.mobile-commons.inc
@@ -1,37 +1,6 @@
+*|CAMPAIGN_TITLE|*
+*|CALL_TO_ACTION|*
+*|TIP_TITLE|* - *|DURING_TIP|*
 
-<table border="0" cellpadding="0" cellspacing="0" class="mcnCaptionRightContentOuter" width="100%">
-  <tbody><tr>
-    <td valign="top" class="mcnCaptionRightContentInner" style="padding:0 9px 0 0 ;">
-      <table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnCaptionRightImageContentContainer">
-        <tbody><tr>
-          <td class="mcnCaptionRightImageContent" valign="top">
-            <a href="*|CAMPAIGN_LINK|*" title="" class="" target="_blank">
-              <img src="*|CAMPAIGN_IMAGE_URL|*" class="mcnImage">
-            </a>
-          </td>
-        </tr></tbody>
-      </table>
-      <table class="mcnCaptionRightTextContentContainer" align="right" border="0" cellpadding="0" cellspacing="0" width="244" style="padding-left: 8px;">
-        <tbody><tr>
-          <td valign="top" class="mcnTextContent">
-            <center>
-              <h2 class="null" dir="ltr" style="text-align: left;"><span style="font-size:24px">*|CAMPAIGN_TITLE|*</span></h2>
-              <h3 class="null" dir="ltr" style="text-align: left;"><font size="4">*|CALL_TO_ACTION|*</font></h3>
-              <p dir="ltr" style="text-align: left;"><strong>*|TIP_TITLE|*</strong>&nbsp;*|DURING_TIP|*</p>
-            </center>
-            <center>
-              <table border="0" cellpadding="0" cellspacing="0" class="emailButton" style="border-radius:3px; background-color:#23b7fb;" mc:edit="buttonlink">
-                <tbody>
-                  <tr>
-                    <td align="center" class="emailButtonContent" style="padding-top:16px; padding-right:16px; padding-bottom:16px; padding-left:16px;" valign="middle"><a href="*|CAMPAIGN_LINK|*" style="color:#FFFFFF; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; text-decoration:none;" target="_blank">DID IT? PROVE IT!</a>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </center>
-          </td>
-        </tr></tbody>
-      </table>
-    </td>
-  </tr></tbody>
-</table>
+DID IT? PROVE IT!
+*|CAMPAIGN_LINK|*


### PR DESCRIPTION
- Processing `campaign_signup` transaction requests as batches grouped by `$address` on intervals.
- Support `shim` message processing to add timed "keep alive" processing when message traffic is idle.
