### PR TITLE
Fix PHP Parse error

### DIFF
--- a/mbp-logging-reports/tests/MBC_LoggingReportsTest.php
+++ b/mbp-logging-reports/tests/MBC_LoggingReportsTest.php
@@ -8,7 +8,7 @@ namespace DoSomething\MBC_LoggingReports\Test;
 /**
  * MBP_LoggingReportsTest: test coverage for MBP_LoggingReports class.
  */
-class MBP_LoggingReportsTest extends PHPUnit_Framework_TestCase {
+#class MBP_LoggingReportsTest extends PHPUnit_Framework_TestCase {
  
 class MBC_LoggingProcessoryTest extends PHPUnit_Framework_TestCase {
   


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected 'class' (T_CLASS), expecting function (T_FUNCTION) in /opt/rabbit/MessageBroker-PHP/mbp-logging-reports/tests/MBC_LoggingReportsTest.php on line 13
Script ./vendor/bin/phpunit tests handling the post-package-update event returned with error code 255
