### PR TITLE
mbc-logging-processor: Fixes PHP fatal error.

### DIFF
--- a/mbc-logging-processor/composer.json
+++ b/mbc-logging-processor/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">= 5.3.0",
     "DoSomething/messagebroker-phplib": "0.2.*",
-    "dosomething/mb-toolbox": "0.8.*",
+    "dosomething/mb-toolbox": "0.9.*",
     "dosomething/stathat": "1.*"
   },
   "require-dev": {


### PR DESCRIPTION
Fix for #56.

`mb-toolbox` v0.9 forces all messages to be converted to assoc arrays:
https://github.com/DoSomething/mb-toolbox/compare/0.8.21...0.9.13#diff-32cde65ef29062db3567224b8794a192R121

I tested it on `forgot_password` message and processor result is consistent after `mb-toolbox` update.
