### PR TITLE
Fixes Slack message duplicates.

### DIFF
--- a/mbp-logging-reports/src/MBP_LoggingReports_Users.php
+++ b/mbp-logging-reports/src/MBP_LoggingReports_Users.php
@@ -605,8 +605,8 @@ class MBP_LoggingReports_Users
           if (strpos($recipient, '@') !== false) {
             $tos[] = $recipient;
           }
-          $this->slack->alert($channelNames, $attachment, $tos);
         }
+        $this->slack->alert($channelNames, $attachment, $tos);
       }
     }
   }


### PR DESCRIPTION
#### What's this PR do?
- Prevents double reporting to Slack
#### Any background context you want to provide?

I discovered that slack alert should be issued after the list of recipients was built.

Before this fix it would send messages **while** building an array of recipient. Thus it incrementally issues alerts on every iteration. Here's a `var_dump()` report in place of original `$this->slack->alert($channelNames, $attachment, $tos);`:

```
/Users/sergii/Development/qs/MessageBroker-PHP/mbp-logging-reports/src/MBP_LoggingReports_Users.php:615:
array(1) {
  [0] =>
  string(12) "#quicksilver"
}
/Users/sergii/Development/qs/MessageBroker-PHP/mbp-logging-reports/src/MBP_LoggingReports_Users.php:615:
array(2) {
  [0] =>
  string(12) "#quicksilver"
  [1] =>
  string(17) "#niche_monitoring"
}
```

You can see that alert is issued to `#quicksilver` twice. Exactly that is actually happening.
#### What are the relevant tickets?

Fixes #58.
