### PR TITLE
Downgrade minimal required PHP

### DIFF
--- a/messaging-groups-consumer/composer.json
+++ b/messaging-groups-consumer/composer.json
@@ -13,7 +13,7 @@
       }
     ],
   "require": {
-    "php": ">= 5.6.0",
+    "php": ">= 5.5.0",
     "DoSomething/messagebroker-phplib": "0.3.*",
     "dosomething/mb-toolbox": "^0.13.1",
     "dosomething/stathat": "2.*",


### PR DESCRIPTION
Turned out prod has PHP 5.5.9.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - This package requires php >= 5.6.0 but your PHP version (5.5.9) does not satisfy that requirement.
```