### PR TITLE
Turn off log noise on incorrect activities.

### DIFF
--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -154,7 +154,6 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
     if (!in_array($message['activity'], $allowedActivities)) {
       echo '** canProcess(): activity is not supported: '
         . $message['activity'] . '.' . PHP_EOL;
-      parent::reportErrorPayload();
 
       return false;
     }


### PR DESCRIPTION
Don't log full payload when activity is incorrect, that happens way too often.