### PR TITLE
Delayed events: require at least messagebroker-phplib v0.3.8.

### DIFF
--- a/delayed-events/composer.json
+++ b/delayed-events/composer.json
@@ -14,7 +14,7 @@
     ],
   "require": {
     "php": ">= 5.5.0",
-    "DoSomething/messagebroker-phplib": "0.3.*",
+    "DoSomething/messagebroker-phplib": "~0.3.8",
     "dosomething/mb-toolbox": "^0.13.1",
     "dosomething/stathat": "2.*",
     "dosomething/gateway": "@dev",


### PR DESCRIPTION
To include `getAllMessages` functionality.