### PR TITLE
Dry run functionality for delayed messages

### DIFF
--- a/delayed-events/delayed-events-consumer.php
+++ b/delayed-events/delayed-events-consumer.php
@@ -22,6 +22,7 @@ if (isset($_GET['environment']) && allowedEnviroment($_GET['environment'])) {
   define('ENVIRONMENT', 'local');
 }
 
+define("DRY_RUN", in_array('--dry-run', $argv));
 
 // Load up the Composer autoload magic
 require_once __DIR__ . '/vendor/autoload.php';
@@ -30,6 +31,9 @@ require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/delayed-events-consumer.config.inc';
 
 echo '------- delayed-events-consumer START: ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;
+if (DRY_RUN) {
+  echo '@@@@@@@@ DRY RUN MODE ON @@@@@@@@' . PHP_EOL;
+}
 // Kick off - blocking, waiting for messages in the queue
 $mb = $mbConfig->getProperty('messageBroker');
 


### PR DESCRIPTION
Adds `--dry-run` argument for `delayed-events-consumer.php`.
It makes script enter the test mode:
- Doesn't issue real SMS, just a log message instead
- Doesn't affect real data
