### PR TITLE
Avoid race condition in messaging groups by retrying multiple times

### DIFF
--- a/messaging-groups-consumer/composer.json
+++ b/messaging-groups-consumer/composer.json
@@ -17,7 +17,7 @@
     "DoSomething/messagebroker-phplib": "0.3.*",
     "dosomething/mb-toolbox": "^0.13.1",
     "dosomething/stathat": "2.*",
-    "dosomething/gateway": "@dev",
+    "dosomething/gateway": "1.0.0-rc16",
     "league/csv": "^8.1"
   },
   "require-dev": {

--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -73,7 +73,7 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
    *   The contents of the queue entry message being processed.
    */
   public function consumeMessagingGroupsQueue($payload) {
-    echo '------ messaging-groups-consumer - MessagingGroupsConsumer->consumeRegistrationMobileQueue() - ' . date('j D M Y G:i:s T') . ' START ------', PHP_EOL . PHP_EOL;
+    echo '------ ' . date(DATE_ISO8601) . ' messaging-groups-consumer - MessagingGroupsConsumer->consumeRegistrationMobileQueue() START ------' . PHP_EOL . PHP_EOL;
     $this->gambitCampaign = false;
 
     parent::consumeQueue($payload);
@@ -89,7 +89,7 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
         // Ack in Service process() due to nested try/catch
       }
       else {
-        echo '- canProcess() is not passed, removing from queue.', PHP_EOL;
+        echo '- canProcess() is not passed, removing from queue.' . PHP_EOL;
         $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: skipping', 1);
         $this->messageBroker->sendAck($this->message['payload']);
       }
@@ -103,45 +103,44 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
        */
 
       if (!(strpos($e->getMessage(), 'Connection timed out') === false)) {
-        echo '** Connection timed out... waiting before retrying: ' . date('j D M Y G:i:s T') . ' - getMessage(): ' . $e->getMessage(), PHP_EOL;
+        echo '** ' . date(DATE_ISO8601) . ' Connection timed out... waiting before retrying: - getMessage(): ' . $e->getMessage() . PHP_EOL;
         $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Connection timed out', 1);
         sleep(self::RETRY_SECONDS);
         $this->messageBroker->sendNack($this->message['payload']);
-        echo '- Nack sent to requeue message: ' . date('j D M Y G:i:s T'), PHP_EOL . PHP_EOL;
+        echo '- ' . date(DATE_ISO8601) . ' Nack sent to requeue message: ' . PHP_EOL . PHP_EOL;
       }
       elseif (!(strpos($e->getMessage(), 'Operation timed out') === false)) {
-        echo '** Operation timed out... waiting before retrying: ' . date('j D M Y G:i:s T') . ' - getMessage(): ' . $e->getMessage(), PHP_EOL;
+        echo '** ' . date(DATE_ISO8601) . ' Operation timed out... waiting before retrying: - getMessage(): ' . $e->getMessage() . PHP_EOL;
         $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Operation timed out', 1);
         sleep(self::RETRY_SECONDS);
         $this->messageBroker->sendNack($this->message['payload']);
-        echo '- Nack sent to requeue message: ' . date('j D M Y G:i:s T'), PHP_EOL . PHP_EOL;
+        echo '- ' . date(DATE_ISO8601) . ' Nack sent to requeue message: ' . PHP_EOL . PHP_EOL;
       }
       elseif (!(strpos($e->getMessage(), 'Failed to connect') === false)) {
-        echo '** Failed to connect... waiting before retrying: ' . date('j D M Y G:i:s T') . ' - getMessage(): ' . $e->getMessage(), PHP_EOL;
+        echo '** ' . date(DATE_ISO8601) . ' Failed to connect... waiting before retrying: - getMessage(): ' . $e->getMessage() . PHP_EOL;
         sleep(self::RETRY_SECONDS);
         $this->messageBroker->sendNack($this->message['payload']);
-        echo '- Nack sent to requeue message: ' . date('j D M Y G:i:s T'), PHP_EOL . PHP_EOL;
+        echo '- ' . date(DATE_ISO8601) . ' Nack sent to requeue message: ' . PHP_EOL . PHP_EOL;
         $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Failed to connect', 1);
       }
       elseif (!(strpos($e->getMessage(), 'Bad response - HTTP Code:500') === false)) {
-        echo '** Connection error, http code 500... waiting before retrying: ' . date('j D M Y G:i:s T') . ' - getMessage(): ' . $e->getMessage(), PHP_EOL;
+        echo '** ' . date(DATE_ISO8601) . ' Connection error, http code 500... waiting before retrying: - getMessage(): ' . $e->getMessage() . PHP_EOL;
         sleep(self::RETRY_SECONDS);
         $this->messageBroker->sendNack($this->message['payload']);
-        echo '- Nack sent to requeue message: ' . date('j D M Y G:i:s T'), PHP_EOL . PHP_EOL;
+        echo '- ' . date(DATE_ISO8601) . ' Nack sent to requeue message: ' . PHP_EOL . PHP_EOL;
         $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Bad response - HTTP Code:500', 1);
       }
       elseif ($e->getCode() === self::RETRY_SIGNAL) {
-        echo '** Retry signal caught, waiting before retrying: ' . date('j D M Y G:i:s T') . ' - getMessage(): '
+        echo '** ' . date(DATE_ISO8601) . ' Retry signal caught, waiting before retrying: - getMessage(): '
           . PHP_EOL . $e->getMessage() . PHP_EOL;
         sleep(self::RETRY_SECONDS);
         if ($this->message['payload']->get('delivery_tag') <= self::RETRY_SIGNAL_ATTEMPTS) {
           $this->messageBroker->sendNack($this->message['payload']);
-          echo '- Nack sent to requeue message: ' . date('j D M Y G:i:s T')
-            . '. Attempt ' . $this->message['payload']->get('delivery_tag') . PHP_EOL;
+          echo '- ' . date(DATE_ISO8601) . ' Nack sent to requeue message. Attempt ' . $this->message['payload']->get('delivery_tag') . PHP_EOL;
           $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Retry signal', 1);
         } else {
           // Max attempt has reached, saving message to deadLetterQueue.
-          echo '- Exception: Retry signal: Max attempt reached. Saving message to deadLetterQueue ' . date('j D M Y G:i:s T') . PHP_EOL;
+          echo '- ' . date(DATE_ISO8601) . ' Exception: Retry signal: Max attempt reached. Saving message to deadLetterQueue ' . PHP_EOL;
           parent::deadLetter($this->message, 'MessagingGroupsConsumer->consumeRegistrationMobileQueue() Error', $e);
 
           // Nack without requeueing.
@@ -150,8 +149,8 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
         }
       }
       else {
-        echo '- Not timeout or connection error, message to deadLetterQueue: ' . date('j D M Y G:i:s T'), PHP_EOL;
-        echo '- Error message: ' . $e->getMessage(), PHP_EOL;
+        echo '- ' . date(DATE_ISO8601) . ' Not timeout or connection error, message to deadLetterQueue: ' . PHP_EOL;
+        echo '- Error message: ' . $e->getMessage() . PHP_EOL;
 
         // Unknown exception, save the message to deadLetter queue.
         $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: deadLetter', 1);
@@ -166,7 +165,7 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
     // waiting to be processed start / stop consumers. Make "reactive"!
     $queueStatus = parent::queueStatus('messagingGroupsQueue');
 
-    echo  PHP_EOL . '------ messaging-groups-consumer - MessagingGroupsConsumer->consumeRegistrationMobileQueue() - ' . date('j D M Y G:i:s T') . ' END ------', PHP_EOL . PHP_EOL;
+    echo  PHP_EOL . '------ ' . date(DATE_ISO8601) . ' messaging-groups-consumer - MessagingGroupsConsumer->consumeRegistrationMobileQueue() END ------' . PHP_EOL . PHP_EOL;
   }
 
   /**

--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -140,12 +140,12 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
             . '. Attempt ' . $this->message['payload']->get('delivery_tag') . PHP_EOL;
           $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Retry signal', 1);
         } else {
-          // Max attempt has reached, saving message to deadLetter queue.
+          // Max attempt has reached, saving message to deadLetterQueue.
+          echo '- Exception: Retry signal: Max attempt reached. Saving message to deadLetterQueue ' . date('j D M Y G:i:s T') . PHP_EOL;
           parent::deadLetter($this->message, 'MessagingGroupsConsumer->consumeRegistrationMobileQueue() Error', $e);
 
           // Nack without requeueing.
           $this->messageBroker->sendNack($this->message['payload'], false, false);
-          echo '- Exception: Retry signal: Max attempt reached. ' . date('j D M Y G:i:s T') . PHP_EOL;
           $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Retry signal: Max attempt reached', 1);
         }
       }

--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -140,6 +140,10 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
             . '. Attempt ' . $this->message['payload']->get('delivery_tag') . PHP_EOL;
           $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Retry signal', 1);
         } else {
+          // Max attempt has reached, saving message to deadLetter queue.
+          parent::deadLetter($this->message, 'MessagingGroupsConsumer->consumeRegistrationMobileQueue() Error', $e);
+
+          // Nack without requeueing.
           $this->messageBroker->sendNack($this->message['payload'], false, false);
           echo '- Exception: Retry signal: Max attempt reached. ' . date('j D M Y G:i:s T') . PHP_EOL;
           $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: Retry signal: Max attempt reached', 1);
@@ -149,7 +153,7 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
         echo '- Not timeout or connection error, message to deadLetterQueue: ' . date('j D M Y G:i:s T'), PHP_EOL;
         echo '- Error message: ' . $e->getMessage(), PHP_EOL;
 
-        // Uknown exception, save the message to deadLetter queue.
+        // Unknown exception, save the message to deadLetter queue.
         $this->statHat->ezCount('messaging-groups-consumer: MessagingGroupsConsumer: Exception: deadLetter', 1);
         parent::deadLetter($this->message, 'MessagingGroupsConsumer->consumeRegistrationMobileQueue() Error', $e);
 

--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -45,7 +45,7 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
 
     if (count($this->gambitCampaignsCache) < 1) {
       // Basically, die.
-      throw new Exception('No gambit connetion.');
+      throw new Exception('No gambit connection.');
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?
- Introduces retry code `RETRY_SIGNAL` to signal consumer to retry after a pause `RETRY_SECONDS`
- Introduces new `RETRY_SIGNAL_ATTEMPTS` to limit retry attempts
- Improves messaging groups logging

#### Where should the reviewer start?
👁 

#### Any background context you want to provide?
See https://github.com/DoSomething/Quicksilver-PHP/issues/87#issuecomment-274912543

#### What are the relevant tickets?
Fixes #87.
Trello: https://trello.com/c/bVsHT6v0/234-8-quicksilver-create-a-solution-to-the-moco-messaging-group-error
