### PR TITLE
Filter out non-US users from messaging groups

### DIFF
--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -213,6 +213,14 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
       return false;
     }
 
+    // Only US users are allowed.
+    if (!empty($message['user_country']) && $message['user_country'] !== 'US') {
+      echo '** canProcess(): Unsupported country: '
+        . $message['user_country'] . '.' . PHP_EOL;
+
+      return false;
+    }
+
 
     // Check activity presence.
     if (empty($message['activity'])) {

--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -221,7 +221,6 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
       return false;
     }
 
-
     // Check activity presence.
     if (empty($message['activity'])) {
       echo '** canProcess(): activity not set.' . PHP_EOL;


### PR DESCRIPTION
To prevent users with `US` application id, but non-US user country from being processed in MobileCommons.