### PR TITLE
Ignore closed campaigns

### DIFF
--- a/messaging-groups-consumer/composer.json
+++ b/messaging-groups-consumer/composer.json
@@ -17,7 +17,7 @@
     "DoSomething/messagebroker-phplib": "0.3.*",
     "dosomething/mb-toolbox": "^0.13.1",
     "dosomething/stathat": "2.*",
-    "dosomething/gateway": "1.0.0-rc16",
+    "dosomething/gateway": "1.0.0-rc17",
     "league/csv": "^8.1"
   },
   "require-dev": {

--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -58,7 +58,7 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
 
     // Cache gambit campaigns,
     $gambit = $this->mbConfig->getProperty('gambit');
-    $gambitCampaigns = $gambit->getAllCampaigns();
+    $gambitCampaigns = $gambit->getAllCampaigns(['campaignbot' => true]);
 
     foreach ($gambitCampaigns as $campaign) {
       if ($campaign->status != 'closed') {

--- a/messaging-groups-consumer/src/MessagingGroupsConsumer.php
+++ b/messaging-groups-consumer/src/MessagingGroupsConsumer.php
@@ -61,7 +61,7 @@ class MessagingGroupsConsumer extends MB_Toolbox_BaseConsumer
     $gambitCampaigns = $gambit->getAllCampaigns();
 
     foreach ($gambitCampaigns as $campaign) {
-      if ($campaign->campaignbot === true) {
+      if ($campaign->status != 'closed') {
         $this->gambitCampaignsCache[$campaign->id] = $campaign;
       }
     }


### PR DESCRIPTION
Fixes issue with closed Gambit campaigns being treated as active, just because Campaignbot is enabled.
