### PR TITLE
Exclude all fake import addresses

### DIFF
--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -168,6 +168,12 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
       return false;
     }
 
+    // Exclude generated emails adresses.
+    if (preg_match('/@.*\.import$/', $message['email'])) {
+      echo '- canProcess(), import placeholder address: ' . $message['email'], PHP_EOL;
+      return false;
+    }
+
     if (empty($message['activity'])) {
       return false;
     }


### PR DESCRIPTION
#### What's this PR do?
- Excludes all possible combinations of fake import email addresses from being processed

#### Any background context you want to provide?
Drupal requires an email on every account, but Northstar does not. In order to create Phoenix profile for SMS-only users, we generate fake email address `id@@dosomething.import`, see https://github.com/DoSomething/northstar/pull/507/files#diff-eb9950cc3e4522e41dd68c31824f0497R125. This PR is to handle this exception and exclude this addresses from normal transactional email processing.

#### What are the relevant tickets?
- Same issue in mbc-transaction-email https://github.com/DoSomething/mbc-transactional-email/pull/49
- Same issue in mbc-registration-email https://github.com/DoSomething/mbc-registration-email/pull/74
- Trello https://trello.com/c/kt6mnl28/299-unplanned-exclude-fake-addresses-from-transactional-digest
- Trello https://trello.com/c/QRfWx8sn/288-unplanned-filter-out-dosomething-import-emails-from-being-processed
