### PR TITLE
Exclude "Give A Spit About Cancer: Share" from relative reminders

### DIFF
--- a/delayed-events/src/DelayedEventsConsumer.php
+++ b/delayed-events/src/DelayedEventsConsumer.php
@@ -262,6 +262,8 @@ class DelayedEventsConsumer extends MB_Toolbox_BaseConsumer
     $mutedCampaigns = [
       // Niche SMS-game campaign.
       7703,
+      // Give A Spit About Cancer: Share
+      7693,
     ];
     if (in_array($campaignId, $mutedCampaigns)) {
       echo '** canProcess(): Campaign is muted: '


### PR DESCRIPTION
Per Freddie Bologno's request, exclude "Give A Spit About Cancer: Share" from relative SMS reminders.