### PR TITLE
Suppress email digest for "Sincerely, Us"

### DIFF
--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -209,6 +209,9 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
       // Car Sticky Note Challange
       // https://www.dosomething.org/us/campaigns/car-sticky-note-challange
       7675,
+      // Sincerely, Us
+      // https://www.dosomething.org/us/campaigns/sincerely-us
+      7656,
     ];
     if (in_array($message['event_id'], $disabledCampaigns)) {
       echo '- Campaign signup communication is disabled.' . PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?
Completely suppress signup emails for "Sincerely, Us".
This is first part of two PRs, the second will enable custom transactional signup templates.

#### What are the relevant tickets?
Pivotal: https://www.pivotaltracker.com/story/show/143442359