### PR TITLE
Mute Unlock the Truth and Mirror Messages digest

### DIFF
--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -212,6 +212,12 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
       // Sincerely, Us
       // https://www.dosomething.org/us/campaigns/sincerely-us
       7656,
+      // Unlock the Truth
+      // https://www.dosomething.org/us/campaigns/uncover-truth
+      7771,
+      // Mirror Messages
+      // https://www.dosomething.org/us/campaigns/mirror-messages
+      7,
     ];
     if (in_array($message['event_id'], $disabledCampaigns)) {
       echo '- Campaign signup communication is disabled.' . PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?
Completely suppress signup emails for "Unlock the Truth" and "Mirror Messages".
This is first part of two PRs, the second will enable custom transactional signup templates.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/144491217