### PR TITLE
Mute transactional digest for July 2017 campaigns

### DIFF
--- a/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
+++ b/mbc-transactional-digest/src/MBC_TransactionalDigest_Consumer.php
@@ -218,6 +218,15 @@ class MBC_TransactionalDigest_Consumer extends MB_Toolbox_BaseConsumer
       // Mirror Messages
       // https://www.dosomething.org/us/campaigns/mirror-messages
       7,
+      // All in We Win
+      // https://www.dosomething.org/us/campaigns/all-we-win
+      7831,
+      // Treat Yo Friends
+      // https://www.dosomething.org/us/campaigns/treat-yo-friends
+      5646,
+      // Steps for Soldiers
+      // https://www.dosomething.org/us/campaigns/steps-soldiers
+      7822,
     ];
     if (in_array($message['event_id'], $disabledCampaigns)) {
       echo '- Campaign signup communication is disabled.' . PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?
Completely suppress signup emails for "All in We Win",  "Treat Yo Friends " and "Steps for Soldiers".
This is the first part of two PRs, the second will enable custom transactional signup templates.

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/147458033